### PR TITLE
CI: harden GHA configuration

### DIFF
--- a/AD{{ cookiecutter.driver_name }}/.github/workflows/pre-commit.yaml
+++ b/AD{{ cookiecutter.driver_name }}/.github/workflows/pre-commit.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
This adjusts the defaults per suggestions of zizmor to
reduce possible risks from giving GHA tasks more permissions
that required.
