### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/AD{{ cookiecutter.driver_name }}/.github/workflows/pre-commit.yaml
+++ b/AD{{ cookiecutter.driver_name }}/.github/workflows/pre-commit.yaml
@@ -1,4 +1,6 @@
 name: Pre-commit
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
